### PR TITLE
Add context menu command

### DIFF
--- a/jupyterlab_wipp_plugin_creator/src/index.ts
+++ b/jupyterlab_wipp_plugin_creator/src/index.ts
@@ -74,6 +74,22 @@ const plugin: JupyterFrontEndPlugin<void> = {
     sidebar.title.iconClass = 'wipp-pluginCreatorLogo jp-SideBar-tabIcon';
     sidebar.title.caption = 'WIPP Plugin Creator';
     labShell.add(sidebar, 'left', { rank: 200 });
+
+    // Create command for context menu
+    const addFileToPluginContextMenuCommandID = 'wipp-plugin-creator-add-context-menu';
+    app.commands.addCommand(addFileToPluginContextMenuCommandID, {
+      label: 'Add to the new WIPP plugin',
+      iconClass: 'jp-MaterialIcon jp-AddIcon',
+      isVisible: () => ['notebook', 'file'].includes(factory.tracker.currentWidget!.selectedItems().next()!.type),
+      execute: () => console.log(factory.tracker.currentWidget!.selectedItems().next()!.path)
+    });
+
+    // Add command to context menu
+    const selectorItem = '.jp-DirListing-item[data-isdir]';
+    app.contextMenu.addItem({
+      command: addFileToPluginContextMenuCommandID,
+      selector: selectorItem
+    })
   }
 };
 


### PR DESCRIPTION
Here is a little starter for context menu command. You can test it by selecting file, clicking right mouse button and selecting 'Add to the new WIPP plugin'. It should print the file path to the browser developer console.

`factory.tracker.currentWidget!.selectedItems().next()!.path` will contain the path to the selected file (relative to the root)
You should replace `console.log` with your own function that is going to add the path to the list of paths stored in `IStateDB`

`isVisible` contains a filer that only shows the button if file type is notebook or file (not folders).